### PR TITLE
Add logging of EventId

### DIFF
--- a/src/Gelf.Extensions.Logging/GelfLogger.cs
+++ b/src/Gelf.Extensions.Logging/GelfLogger.cs
@@ -33,6 +33,8 @@ namespace Gelf.Extensions.Logging
                 Host = _options.LogSource,
                 Level = GetLevel(logLevel),
                 Timestamp = GetTimestamp(),
+                EventId = eventId.Id,
+                EventName = eventId.Name,
                 AdditionalFields = _options.AdditionalFields
                     .Concat(GetStateAdditionalFields(state, exception))
                     .Concat(GetScopeAdditionalFields())

--- a/src/Gelf.Extensions.Logging/GelfMessage.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessage.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Gelf.Extensions.Logging
 {
-    // http://docs.graylog.org/en/2.2/pages/gelf.html#gelf-payload-specification
+    // http://docs.graylog.org/en/2.4/pages/gelf.html#gelf-payload-specification
     public class GelfMessage
     {
         [JsonProperty("version")]
@@ -20,6 +20,12 @@ namespace Gelf.Extensions.Logging
 
         [JsonProperty("level")]
         public SyslogSeverity Level { get; set; }
+
+        [JsonProperty("eventid", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int EventId { get; set; }
+
+        [JsonProperty("eventname", NullValueHandling = NullValueHandling.Ignore)]
+        public string EventName { get; set; }
 
         [JsonIgnore]
         public IEnumerable<KeyValuePair<string, object>> AdditionalFields { get; set; }

--- a/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
@@ -165,6 +165,24 @@ namespace Gelf.Extensions.Logging.Tests
             }
         }
 
+        [Fact]
+        public async Task Log_EventId()
+        {
+            var options = _loggerFixture.LoggerOptions;
+            
+            using (var loggerFactory = _loggerFixture.CreateLoggerFactory(options))
+            {
+                var sut = loggerFactory.CreateLogger(nameof(GelfLoggerTests));
+
+                sut.LogInformation(new EventId(1, "ok"), _faker.Lorem.Sentence());
+                
+                var message = await _graylogFixture.WaitForMessageAsync();
+
+                Assert.Equal(message.eventid, 1);
+                Assert.Equal(message.EventName, "ok");
+            }
+        }
+
         public void Dispose()
         {
             _loggerFixture.Dispose();

--- a/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
@@ -179,7 +179,7 @@ namespace Gelf.Extensions.Logging.Tests
                 var message = await _graylogFixture.WaitForMessageAsync();
 
                 Assert.Equal(message.eventid, 1);
-                Assert.Equal(message.EventName, "ok");
+                Assert.Equal(message.eventname, "ok");
             }
         }
 


### PR DESCRIPTION
Hi,

Logging object support logging an EventId:
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.1&tabs=aspnetcore2x#log-event-id

It seems natural that gelf includes that information if available.

Here it is :)

Note that I couldn't execute tests locally

Thomas