### PR TITLE
Don't add duplicate keys in GELF scopes

### DIFF
--- a/src/Gelf.Extensions.Logging/GelfLogger.cs
+++ b/src/Gelf.Extensions.Logging/GelfLogger.cs
@@ -91,12 +91,18 @@ namespace Gelf.Extensions.Logging
 
         private static IEnumerable<KeyValuePair<string, object>> GetScopeAdditionalFields()
         {
-            var additionalFields = Enumerable.Empty<KeyValuePair<string, object>>();
+            var additionalFields = new Dictionary<string, object>();
 
             var scope = GelfLogScope.Current;
             while (scope != null)
             {
-                additionalFields = additionalFields.Concat(scope.AdditionalFields);
+                foreach(var field in scope.AdditionalFields)
+                {
+                    if(!additionalFields.ContainsKey(field.Key))
+                    {
+                        additionalFields.Add(field.Key, field.Value);
+                    }
+                }
                 scope = scope.Parent;
             }
 

--- a/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
@@ -143,6 +143,25 @@ namespace Gelf.Extensions.Logging.Tests
         }
 
         [Fact]
+        public async Task When_duplicate_scope_keys_inner_scope_should_be_used()
+        {
+            var messageText = _faker.Lorem.Sentence();
+
+            var sut = _loggerFixture.CreateLogger<GelfLoggerTests>();
+            using (sut.BeginScope(("foo", "outer")))
+            {
+                using (sut.BeginScope(("foo", "inner")))
+                {
+                    sut.LogCritical(messageText);
+                }
+            }
+
+            var message = await _graylogFixture.WaitForMessageAsync();
+
+            Assert.Equal("inner", message.foo);
+        }
+
+        [Fact]
         public async Task Sends_message_with_additional_fields_from_structured_log()
         {
             var sut = _loggerFixture.CreateLogger<GelfLoggerTests>();


### PR DESCRIPTION
This fixes issue #15 that nested `BeginScope(...)` with the same key get
overwritten by the outer `BeginScope(...)`