### PR TITLE
Support numbers in GelfMessage.AdditonalFields

### DIFF
--- a/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
@@ -5,13 +5,35 @@ namespace Gelf.Extensions.Logging
 {
     public static class GelfMessageExtensions
     {
+        private static bool IsNumeric(object value)
+        {
+            return value is sbyte
+                || value is byte
+                || value is short
+                || value is ushort
+                || value is int
+                || value is uint
+                || value is long
+                || value is ulong
+                || value is float
+                || value is double
+                || value is decimal;
+        }
+
         public static string ToJson(this GelfMessage message)
         {
             var messageJson = JObject.FromObject(message);
 
             foreach (var field in message.AdditionalFields)
             {
-                messageJson[$"_{field.Key}"] = field.Value?.ToString();
+                if(IsNumeric(field.Value))
+                {
+                    messageJson[$"_{field.Key}"] = JToken.FromObject(field.Value);
+                }
+                else
+                {
+                    messageJson[$"_{field.Key}"] = field.Value?.ToString();
+                }
             }
 
             return JsonConvert.SerializeObject(messageJson, Formatting.None, new JsonSerializerSettings

--- a/src/Gelf.Extensions.Logging/UdpGelfClient.cs
+++ b/src/Gelf.Extensions.Logging/UdpGelfClient.cs
@@ -44,46 +44,6 @@ namespace Gelf.Extensions.Logging
             }
         }
 
-        private static bool IsNumeric(object value)
-        {
-            return value is sbyte
-                || value is byte
-                || value is short
-                || value is ushort
-                || value is int
-                || value is uint
-                || value is long
-                || value is ulong
-                || value is float
-                || value is double
-                || value is decimal;
-        }
-
-        private static byte[] GetMessageBytes(GelfMessage message)
-        {
-            var messageJson = JObject.FromObject(message);
-
-            foreach (var field in message.AdditionalFields)
-            {
-
-                if(IsNumeric(field.Value))
-                {
-                    messageJson[$"_{field.Key}"] = JToken.FromObject(field.Value);
-                }
-                else
-                {
-                    messageJson[$"_{field.Key}"] = field.Value?.ToString();
-                }
-            }
-
-            var messageString = JsonConvert.SerializeObject(messageJson, Formatting.None, new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore
-            });
-
-            return Encoding.UTF8.GetBytes(messageString);
-        }
-
         private static async Task<byte[]> CompressMessageAsync(byte[] messageBytes)
         {
             using (var outputStream = new MemoryStream())

--- a/src/Gelf.Extensions.Logging/UdpGelfClient.cs
+++ b/src/Gelf.Extensions.Logging/UdpGelfClient.cs
@@ -46,13 +46,36 @@ namespace Gelf.Extensions.Logging
             }
         }
 
+        private static bool IsNumeric(object value)
+        {
+            return value is sbyte
+                || value is byte
+                || value is short
+                || value is ushort
+                || value is int
+                || value is uint
+                || value is long
+                || value is ulong
+                || value is float
+                || value is double
+                || value is decimal;
+        }
+
         private static byte[] GetMessageBytes(GelfMessage message)
         {
             var messageJson = JObject.FromObject(message);
 
             foreach (var field in message.AdditionalFields)
             {
-                messageJson[$"_{field.Key}"] = field.Value?.ToString();
+
+                if(IsNumeric(field.Value))
+                {
+                    messageJson[$"_{field.Key}"] = JToken.FromObject(field.Value);
+                }
+                else
+                {
+                    messageJson[$"_{field.Key}"] = field.Value?.ToString();
+                }
             }
 
             var messageString = JsonConvert.SerializeObject(messageJson, Formatting.None, new JsonSerializerSettings

--- a/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
@@ -82,7 +82,7 @@ namespace Gelf.Extensions.Logging.Tests
             var options = LoggerFixture.LoggerOptions;
             options.AdditionalFields["foo"] = "foo";
             options.AdditionalFields["bar"] = "bar";
-            options.AdditionalFields["baz"] = 123;
+            options.AdditionalFields["quux"] = 123;
             var messageText = Faker.Lorem.Sentence();
 
             using (var loggerFactory = LoggerFixture.CreateLoggerFactory(options))
@@ -94,7 +94,7 @@ namespace Gelf.Extensions.Logging.Tests
 
                 Assert.Equal("foo", message.foo);
                 Assert.Equal("bar", message.bar);
-                Assert.Equal(123, message.baz);
+                Assert.Equal(123, message.quux);
             }
         }
 

--- a/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/GelfLoggerTests.cs
@@ -107,6 +107,7 @@ namespace Gelf.Extensions.Logging.Tests
             var options = _loggerFixture.LoggerOptions;
             options.AdditionalFields["foo"] = "foo";
             options.AdditionalFields["bar"] = "bar";
+            options.AdditionalFields["baz"] = 123;
             var messageText = _faker.Lorem.Sentence();
 
             using (var loggerFactory = _loggerFixture.CreateLoggerFactory(options))
@@ -118,6 +119,7 @@ namespace Gelf.Extensions.Logging.Tests
 
                 Assert.Equal("foo", message.foo);
                 Assert.Equal("bar", message.bar);
+                Assert.Equal(123, message.baz);
             }
         }
 
@@ -130,7 +132,8 @@ namespace Gelf.Extensions.Logging.Tests
             using (sut.BeginScope(new Dictionary<string, object>
             {
                 ["baz"] = "baz",
-                ["qux"] = "qux"
+                ["qux"] = "qux",
+                ["quux"] = 123
             }))
             {
                 sut.LogCritical(messageText);
@@ -140,19 +143,21 @@ namespace Gelf.Extensions.Logging.Tests
 
             Assert.Equal("baz", message.baz);
             Assert.Equal("qux", message.qux);
+            Assert.Equal(123, message.quux);
         }
 
         [Fact]
         public async Task Sends_message_with_additional_fields_from_structured_log()
         {
             var sut = _loggerFixture.CreateLogger<GelfLoggerTests>();
-            sut.LogDebug("Structured log line with {first_value} and {second_value}", "foo", "bar");
+            sut.LogDebug("Structured log line with {first_value}, {second_value} and {numeric_value}", "foo", "bar", 123);
 
             var message = await _graylogFixture.WaitForMessageAsync();
 
-            Assert.Equal("Structured log line with foo and bar", message.message);
+            Assert.Equal("Structured log line with foo, bar and 123", message.message);
             Assert.Equal("foo", message.first_value);
             Assert.Equal("bar", message.second_value);
+            Assert.Equal(123, message.numeric_value);
         }
 
         [Fact]


### PR DESCRIPTION
This fixes #17 If an input object is numeric we will treat is as a number in json as well

I also created pull request #19 which takes the content of this and extends the supported `ValueTuple` types in `BeginScope` with all the numeric types of C#