### PR TITLE
Allow log scopes to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,15 @@ var webHost = WebHost
     .UseStartup<Startup>()
     .ConfigureLogging((context, builder) =>
     {
-        // Read GelfLoggerOptions from appsettings.json
-        builder.Services.Configure<GelfLoggerOptions>(context.Configuration.GetSection("Graylog"));
-
-        // Optionally configure GelfLoggerOptions further.
-        builder.Services.PostConfigure<GelfLoggerOptions>(options =>
-            options.AdditionalFields["machine_name"] = Environment.MachineName);
-
         // Read Logging settings from appsettings.json and add providers.
         builder.AddConfiguration(context.Configuration.GetSection("Logging"))
             .AddConsole()
             .AddDebug()
             .AddGelf();
+
+        // Optionally configure GELF logger further.
+        builder.Services.PostConfigure<GelfLoggerOptions>(options =>
+            options.AdditionalFields["machine_name"] = Environment.MachineName);
     })
     .Build();
 ```
@@ -37,7 +34,7 @@ You can then configure the "GELF" provider in `appsettings.json` in the same way
 ```json
 {
   "Logging": {
-    "IncludeScopes": false, 
+    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Error"
     },
@@ -47,19 +44,19 @@ You can then configure the "GELF" provider in `appsettings.json` in the same way
       }
     },
     "GELF": {
+      "Host": "localhost",
+      "Port": 12201,
+      "LogSource": "application-name",
       "IncludeScopes": true,
       "LogLevel": {
         "Default": "Information"
       }
     }
-  },
-  "Graylog": {
-    "Host": "localhost",
-    "Port": 12201,
-    "LogSource": "application-name"
   }
 }
 ```
+
+For a full list of options e.g. UDP/HTTP(S) settings, see [`GelfLoggerOptions`](src/Gelf.Extensions.Logging/GelfLoggerOptions.cs).
 
 ### ASP.NET Core 1.x
 
@@ -81,10 +78,6 @@ public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
     ...
 }
 ```
-
-### Http Headers
-
-Http headers can be added to all logs using Http Protocol by setting them in `GelfLoggerOptions.Headers`.
 
 ### Additional Fields
 

--- a/docker-compose.ci.build.yml
+++ b/docker-compose.ci.build.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   ci-build:
-    image: microsoft/dotnet:2.0-sdk
+    image: microsoft/dotnet:2.1-sdk
     volumes:
       - .:/src
     working_dir: /src

--- a/docker-compose.ci.publish.yml
+++ b/docker-compose.ci.publish.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   ci-build:
-    image: microsoft/dotnet:2.0-sdk
+    image: microsoft/dotnet:2.1-sdk
     volumes:
       - .:/src
     working_dir: /src

--- a/src/Gelf.Extensions.Logging/Gelf.Extensions.Logging.csproj
+++ b/src/Gelf.Extensions.Logging/Gelf.Extensions.Logging.csproj
@@ -39,13 +39,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.8.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
@@ -14,6 +14,11 @@ namespace Gelf.Extensions.Logging
         }
 
         /// <summary>
+        /// Enable/disable additional fields added via log scopes.
+        /// </summary>
+        public bool IncludeScopes { get; set; } = true;
+
+        /// <summary>
         /// Protocol used to send logs.
         /// </summary>
         public GelfProtocol Protocol { get; set; } = GelfProtocol.Udp;
@@ -29,7 +34,7 @@ namespace Gelf.Extensions.Logging
         public int Port { get; set; } = 12201;
 
         /// <summary>
-        /// Log source name mapped to the GELF host field.
+        /// Log source name mapped to the GELF host field (required).
         /// </summary>
         public string LogSource { get; set; }
 
@@ -47,15 +52,15 @@ namespace Gelf.Extensions.Logging
         /// Function used to filter log events based on logger name and level. Uses <see cref="LogLevel"/> by default.
         /// </summary>
 #if NETSTANDARD2_0
-        [Obsolete("Logs should be filtered using LoggerFactory.")]
+        [Obsolete("Filter logs with app config or Microsoft.Extensions.Logging.FilterLoggingBuilderExtensions.")]
 #endif
         public Func<string, LogLevel, bool> Filter { get; set; }
 
         /// <summary>
-        /// The log level used by the default filter. This is ignored if <see cref="Filter"/> is customised.
+        /// The log level used by the default filter. This is ignored if <see cref="Filter"/> is overridden.
         /// </summary>
 #if NETSTANDARD2_0
-        [Obsolete("Logs should be filtered using LoggerFactory.")]
+        [Obsolete("Filter logs with app config or Microsoft.Extensions.Logging.FilterLoggingBuilderExtensions.")]
 #endif
         public LogLevel LogLevel { get; set; } = LogLevel.Information;
 

--- a/src/Gelf.Extensions.Logging/GelfLoggerOptionsSetup.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptionsSetup.cs
@@ -1,0 +1,17 @@
+﻿#if NETSTANDARD2_0
+
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Gelf.Extensions.Logging
+{
+    public class GelfLoggerOptionsSetup : ConfigureFromConfigurationOptions<GelfLoggerOptions>
+    {
+        public GelfLoggerOptionsSetup(ILoggerProviderConfiguration<GelfLoggerProvider> providerConfiguration)
+            : base(providerConfiguration.Configuration)
+        {
+        }
+    }
+}
+
+#endif

--- a/src/Gelf.Extensions.Logging/GelfMessage.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessage.cs
@@ -34,6 +34,6 @@ namespace Gelf.Extensions.Logging
         public string EventName { get; set; }
 
         [JsonIgnore]
-        public IEnumerable<KeyValuePair<string, object>> AdditionalFields { get; set; }
+        public IReadOnlyCollection<KeyValuePair<string, object>> AdditionalFields { get; set; }
     }
 }

--- a/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
@@ -26,7 +26,7 @@ namespace Gelf.Extensions.Logging
 
             foreach (var field in message.AdditionalFields)
             {
-                if(IsNumeric(field.Value))
+                if (IsNumeric(field.Value))
                 {
                     messageJson[$"_{field.Key}"] = JToken.FromObject(field.Value);
                 }

--- a/src/Gelf.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/Gelf.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -2,7 +2,10 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Gelf.Extensions.Logging
 {
@@ -16,7 +19,10 @@ namespace Gelf.Extensions.Logging
         /// <returns></returns>
         public static ILoggingBuilder AddGelf(this ILoggingBuilder builder)
         {
+            builder.AddConfiguration();
             builder.Services.AddSingleton<ILoggerProvider, GelfLoggerProvider>();
+            builder.Services.TryAddSingleton<IConfigureOptions<GelfLoggerOptions>, GelfLoggerOptionsSetup>();
+
             return builder;
         }
 
@@ -29,6 +35,11 @@ namespace Gelf.Extensions.Logging
         /// <returns></returns>
         public static ILoggingBuilder AddGelf(this ILoggingBuilder builder, Action<GelfLoggerOptions> configure)
         {
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
             builder.AddGelf();
             builder.Services.Configure(configure);
             return builder;

--- a/test/Gelf.Extensions.Logging.Tests/Gelf.Extensions.Logging.Tests.csproj
+++ b/test/Gelf.Extensions.Logging.Tests/Gelf.Extensions.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -13,12 +13,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="22.3.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Bogus" Version="24.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Gelf.Extensions.Logging.Tests/LoggingBuilderExtensionsTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/LoggingBuilderExtensionsTests.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Gelf.Extensions.Logging.Tests
+{
+    public class LoggingBuilderExtensionsTests
+    {
+        [Fact]
+        public void Reads_GELF_logger_options_from_logging_configuration_section_by_default()
+        {
+            var configuration = new ConfigurationBuilder().Add(new MemoryConfigurationSource
+            {
+                InitialData = new Dictionary<string, string>
+                {
+                    ["Logging:GELF:IncludeScopes"] = "false",
+                    ["Logging:GELF:Protocol"] = "HTTP",
+                    ["Logging:GELF:Host"] = "graylog-host-1",
+                    ["Graylog:IncludeScopes"] = "true",
+                    ["Graylog:Protocol"] = "HTTPS",
+                    ["Graylog:Host"] = "graylog-host2"
+                }
+            }).Build();
+
+            var serviceCollection = new ServiceCollection()
+                .PostConfigure<GelfLoggerOptions>(o => o.LogSource = "post-configured-log-source")
+                .AddLogging(loggingBuilder => loggingBuilder
+                    .AddConfiguration(configuration.GetSection("Logging"))
+                    .AddGelf());
+
+            using (var provider = serviceCollection.BuildServiceProvider())
+            {
+                var options = provider.GetRequiredService<IOptions<GelfLoggerOptions>>();
+
+                Assert.False(options.Value.IncludeScopes);
+                Assert.Equal(GelfProtocol.Http, options.Value.Protocol);
+                Assert.Equal("graylog-host-1", options.Value.Host);
+                Assert.Equal("post-configured-log-source", options.Value.LogSource);
+            }
+        }
+
+        [Fact]
+        public void Reads_GELF_logger_options_from_custom_configuration_section()
+        {
+            var configuration = new ConfigurationBuilder().Add(new MemoryConfigurationSource
+            {
+                InitialData = new Dictionary<string, string>
+                {
+                    ["Logging:GELF:IncludeScopes"] = "true",
+                    ["Logging:GELF:Protocol"] = "HTTP",
+                    ["Logging:GELF:Host"] = "graylog-host-1",
+                    ["Graylog:IncludeScopes"] = "false",
+                    ["Graylog:Protocol"] = "HTTPS",
+                    ["Graylog:Host"] = "graylog-host-2"
+                }
+            }).Build();
+
+            var serviceCollection = new ServiceCollection()
+                .Configure<GelfLoggerOptions>(configuration.GetSection("Graylog"))
+                .PostConfigure<GelfLoggerOptions>(o => o.LogSource = "post-configured-log-source")
+                .AddLogging(loggingBuilder => loggingBuilder
+                    .AddConfiguration(configuration.GetSection("Logging"))
+                    .AddGelf());
+
+            using (var provider = serviceCollection.BuildServiceProvider())
+            {
+                var options = provider.GetRequiredService<IOptions<GelfLoggerOptions>>();
+
+                Assert.False(options.Value.IncludeScopes);
+                Assert.Equal(GelfProtocol.Https, options.Value.Protocol);
+                Assert.Equal("graylog-host-2", options.Value.Host);
+                Assert.Equal("post-configured-log-source", options.Value.LogSource);
+            }
+        }
+    }
+}


### PR DESCRIPTION
`GelfLoggerOptions` are now read from the "Logging:GELF" section of application config by default meaning `IncludeScopes` now works properly. `GelfMessage.AdditionalFields` are no longer enumerated lazily on background threads which is likely the cause of #27.