### PR TITLE
Pass host to UdpClient constructor to reduce DNS lookups.

### DIFF
--- a/src/Gelf.Extensions.Logging/UdpGelfClient.cs
+++ b/src/Gelf.Extensions.Logging/UdpGelfClient.cs
@@ -24,7 +24,7 @@ namespace Gelf.Extensions.Logging
         public UdpGelfClient(GelfLoggerOptions options)
         {
             _options = options;
-            _udpClient = new UdpClient();
+            _udpClient = new UdpClient(_options.Host, _options.Port);
             _random = new Random();
         }
 
@@ -39,7 +39,7 @@ namespace Gelf.Extensions.Logging
 
             foreach (var messageChunk in ChunkMessage(messageBytes))
             {
-                await _udpClient.SendAsync(messageChunk, messageChunk.Length, _options.Host, _options.Port);
+                await _udpClient.SendAsync(messageChunk, messageChunk.Length);
             }
         }
 


### PR DESCRIPTION
Resolves #50

I was a bit worried how keeping around a bound UDP socket would affect fail-overs and load-balancing over different pods. I [tested those things](https://github.com/svenvanheugten/k8s-udp-test) to be sure, and:
- Fail-overs work fine. When a pod is deleted the subsequent traffic is quickly routed to another pod.
- Load-balancing doesn't seem to work. All traffic is always routed to the same pod. However, this doesn't just happen when using a bound UDP socket, but with _any_ re-use of `UdpClient` instances. I suspect this has to do with https://github.com/kubernetes/kubernetes/issues/76517 and the fact that [`UdpClient` re-uses the same socket even when it is unbound](https://github.com/microsoft/referencesource/blob/master/System/net/System/Net/Sockets/UDPClient.cs#L1044). The only way to avoid this seems to be to create a new `UdpClient` for every message, but that's a different issue (if it is an issue at all).