### PR TITLE
 Add additional function fields into option and send evaluated values as the additional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ _logger.LogInformation("Order {order_id} took {order_time} seconds to process", 
 
 Here the message will contain `order_id` and `order_time` fields.
 
+#### Global Functional Fields
+
+Global functional fields can be added to all logs by setting them in `GelfLoggerOptions.AdditionalFunctionFields`. This can be useful when additional processing needed over log message. You can register functions on initial configuration by adding them into `Dictionary<string, Func<GelfMessage, object>>`.
+
+```csharp
+public static IHostBuilder CreateHostBuilder(string[] args) => Host
+    .CreateDefaultBuilder(args)
+    .ConfigureWebHostDefaults(webBuilder =>
+    {
+        webBuilder
+            .UseStartup<Startup>()
+            .ConfigureLogging((context, builder) => builder.AddGelf(options =>
+            {
+                options.AdditionalFunctionFields.Add("loglevel", message => message.Level.ToString());
+                options.AdditionalFunctionFields.Add("exceptiontype", message => message.Exception?.Split(':')[0]);
+            }));
+    });
+```
+
 ### Log Filtering
 
 The "GELF" provider can be filtered in the same way as the default providers (details [here](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.0#log-filtering)).

--- a/src/Gelf.Extensions.Logging/GelfLogger.cs
+++ b/src/Gelf.Extensions.Logging/GelfLogger.cs
@@ -48,12 +48,11 @@ namespace Gelf.Extensions.Logging
                 Level = GetLevel(logLevel),
                 Timestamp = GetTimestamp(),
                 Logger = _name,
-                Exception = exception?.ToString(),
-                OriginalData = new OriginalData(logLevel, eventId, exception)
+                Exception = exception?.ToString()
             };
 
             var additionalFields = _options.AdditionalFields
-                .Concat(GetComputedAdditionalFieldsFromAdditionalFieldsFactory(message.OriginalData))
+                .Concat(GetComputedAdditionalFieldsFromAdditionalFieldsFactory(logLevel, eventId, exception))
                 .Concat(GetScopeAdditionalFields())
                 .Concat(GetStateAdditionalFields(state));
 
@@ -129,9 +128,9 @@ namespace Gelf.Extensions.Logging
             return additionalFields.Reverse();
         }
 
-        private IEnumerable<KeyValuePair<string, object>> GetComputedAdditionalFieldsFromAdditionalFieldsFactory(OriginalData originalData)
+        private IEnumerable<KeyValuePair<string, object>> GetComputedAdditionalFieldsFromAdditionalFieldsFactory(LogLevel logLevel, EventId eventId, Exception? exception)
         {
-            return _options.AdditionalFieldsFactory.Invoke(originalData.LogLevel, originalData.EventId, originalData.Exception) ??
+            return _options.AdditionalFieldsFactory.Invoke(logLevel, eventId, exception) ??
                    Enumerable.Empty<KeyValuePair<string, object>>();
         }
 

--- a/src/Gelf.Extensions.Logging/GelfLogger.cs
+++ b/src/Gelf.Extensions.Logging/GelfLogger.cs
@@ -59,9 +59,9 @@ namespace Gelf.Extensions.Logging
             if (_options.AdditionalFunctionFields.Count > 0)
             {
                 additionalFields = _options.AdditionalFields
+                    .Concat(GetEvaluatedAdditionalFunctionFields(message))
                     .Concat(GetScopeAdditionalFields())
-                    .Concat(GetStateAdditionalFields(state))
-                    .Concat(GetEvaluatedAdditionalFunctionFields(message));
+                    .Concat(GetStateAdditionalFields(state));
 
                 message.AdditionalFields = ValidateAdditionalFields(additionalFields).ToArray();
             }

--- a/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
@@ -6,57 +6,62 @@ namespace Gelf.Extensions.Logging
     public class GelfLoggerOptions
     {
         /// <summary>
-        /// Enable/disable additional fields added via log scopes.
+        ///     Enable/disable additional fields added via log scopes.
         /// </summary>
         public bool IncludeScopes { get; set; } = true;
 
         /// <summary>
-        /// Protocol used to send logs.
+        ///     Protocol used to send logs.
         /// </summary>
         public GelfProtocol Protocol { get; set; } = GelfProtocol.Udp;
 
         /// <summary>
-        /// GELF server host.
+        ///     GELF server host.
         /// </summary>
         public string? Host { get; set; }
 
         /// <summary>
-        /// GELF server port.
+        ///     GELF server port.
         /// </summary>
         public int Port { get; set; } = 12201;
 
         /// <summary>
-        /// Log source name mapped to the GELF host field (required).
+        ///     Log source name mapped to the GELF host field (required).
         /// </summary>
         public string? LogSource { get; set; }
 
         /// <summary>
-        /// Enable GZip message compression for UDP logging.
+        ///     Enable GZip message compression for UDP logging.
         /// </summary>
         public bool CompressUdp { get; set; } = true;
 
         /// <summary>
-        /// The UDP message size in bytes under which messages will not be compressed.
+        ///     The UDP message size in bytes under which messages will not be compressed.
         /// </summary>
         public int UdpCompressionThreshold { get; set; } = 512;
 
         /// <summary>
-        /// Additional fields that will be attached to all log messages.
+        ///     Additional fields that will be attached to all log messages.
         /// </summary>
         public Dictionary<string, object> AdditionalFields { get; set; } = new Dictionary<string, object>();
 
         /// <summary>
-        /// Headers used when sending logs via HTTP(S).
+        ///     Additional function fields that will be evaluated base on some other log message info and attached to all log messages.
+        /// </summary>
+        public Dictionary<string, Func<GelfMessage, object>> AdditionalFunctionFields { get; set; } = new Dictionary<string, Func<GelfMessage, object>>();
+
+        /// <summary>
+        ///     Headers used when sending logs via HTTP(S).
         /// </summary>
         public Dictionary<string, string> HttpHeaders { get; set; } = new Dictionary<string, string>();
 
         /// <summary>
-        /// Timeout used when sending logs via HTTP(S).
+        ///     Timeout used when sending logs via HTTP(S).
         /// </summary>
         public TimeSpan HttpTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Include a field with the original message template before structured log parameters are replaced.
+        ///     Include a field with the original message template before structured log parameters are replaced.
         /// </summary>
         public bool IncludeMessageTemplates { get; set; }
     }

--- a/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace Gelf.Extensions.Logging
 {
@@ -46,9 +47,10 @@ namespace Gelf.Extensions.Logging
         public Dictionary<string, object> AdditionalFields { get; set; } = new Dictionary<string, object>();
 
         /// <summary>
-        ///     Additional function fields that will be evaluated base on some other log message info and attached to all log messages.
+        ///     Compute additional fields based on raw log data.
         /// </summary>
-        public Dictionary<string, Func<GelfMessage, object>> AdditionalFunctionFields { get; set; } = new Dictionary<string, Func<GelfMessage, object>>();
+        public Func<LogLevel, EventId?, Exception?, Dictionary<string, object>?> AdditionalFieldsFactory { get; set; } =
+            (loglevel, eventId, exception) => new Dictionary<string, object>();
 
         /// <summary>
         ///     Headers used when sending logs via HTTP(S).

--- a/src/Gelf.Extensions.Logging/GelfMessage.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 
 namespace Gelf.Extensions.Logging
 {
@@ -25,25 +24,7 @@ namespace Gelf.Extensions.Logging
 
         public string? EventName { get; set; }
 
-        public OriginalData? OriginalData { get; set; }
-
         public IReadOnlyCollection<KeyValuePair<string, object>> AdditionalFields { get; set; } =
             Array.Empty<KeyValuePair<string, object>>();
-    }
-
-    public class OriginalData
-    {
-        public OriginalData(LogLevel logLevel, EventId? eventId, Exception? exception)
-        {
-            LogLevel = logLevel;
-            EventId = eventId;
-            Exception = exception;
-        }
-
-        public LogLevel LogLevel { get; }
-
-        public EventId? EventId { get; }
-
-        public Exception? Exception { get; }
     }
 }

--- a/src/Gelf.Extensions.Logging/GelfMessage.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace Gelf.Extensions.Logging
 {
@@ -24,7 +25,25 @@ namespace Gelf.Extensions.Logging
 
         public string? EventName { get; set; }
 
+        public OriginalData? OriginalData { get; set; }
+
         public IReadOnlyCollection<KeyValuePair<string, object>> AdditionalFields { get; set; } =
             Array.Empty<KeyValuePair<string, object>>();
+    }
+
+    public class OriginalData
+    {
+        public OriginalData(LogLevel logLevel, EventId? eventId, Exception? exception)
+        {
+            LogLevel = logLevel;
+            EventId = eventId;
+            Exception = exception;
+        }
+
+        public LogLevel LogLevel { get; }
+
+        public EventId? EventId { get; }
+
+        public Exception? Exception { get; }
     }
 }


### PR DESCRIPTION
This is code for enabling new additional function fields that can be used for new calculable values for additional fields. It's related to the colleague's issue/request #52 

Really minimal adjustment in GelfLogger.cs.

Usage is simple, shown in updated [README.md](https://github.com/hercegyu/gelf-extensions-logging#global-functional-fields)

Also, the code includes 2 new tests, covering this new feature. 