### PR TITLE
Auto reload options

### DIFF
--- a/Gelf.Extensions.Logging.sln
+++ b/Gelf.Extensions.Logging.sln
@@ -34,6 +34,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gelf.Extensions.Logging.Sam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gelf.Extensions.Logging.Samples.AspNetCore2", "samples\Gelf.Extensions.Logging.Samples.AspNetCore2\Gelf.Extensions.Logging.Samples.AspNetCore2.csproj", "{C3D38DAC-25E5-4590-A47D-08A97520C4CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gelf.Extensions.Logging.Samples.AspNetCore5", "samples\Gelf.Extensions.Logging.Samples.AspNetCore5\Gelf.Extensions.Logging.Samples.AspNetCore5.csproj", "{5F202815-647E-488A-9B2C-A746775DBF6B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,6 +66,10 @@ Global
 		{C3D38DAC-25E5-4590-A47D-08A97520C4CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3D38DAC-25E5-4590-A47D-08A97520C4CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3D38DAC-25E5-4590-A47D-08A97520C4CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F202815-647E-488A-9B2C-A746775DBF6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F202815-647E-488A-9B2C-A746775DBF6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F202815-647E-488A-9B2C-A746775DBF6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F202815-647E-488A-9B2C-A746775DBF6B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -75,6 +81,7 @@ Global
 		{C55B368D-E4C1-42D0-97C2-4AD2F443743B} = {7D9416E1-13A5-4A86-A3F1-2289369D7193}
 		{7599B625-DD65-4B68-ACF3-6E9400C0A99B} = {7D9416E1-13A5-4A86-A3F1-2289369D7193}
 		{C3D38DAC-25E5-4590-A47D-08A97520C4CB} = {7D9416E1-13A5-4A86-A3F1-2289369D7193}
+		{5F202815-647E-488A-9B2C-A746775DBF6B} = {7D9416E1-13A5-4A86-A3F1-2289369D7193}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C6D74A71-1746-4865-AAE2-77625B3E8935}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Logger options are taken from the "GELF" provider section in `appsettings.json` 
 
 For a full list of options e.g. UDP/HTTP(S) settings, see [`GelfLoggerOptions`](src/Gelf.Extensions.Logging/GelfLoggerOptions.cs). See the [samples](/samples) directory full examples. For more information on providers and logging in general, see the aspnetcore [logging documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging).
 
+### Auto Reloading Config
+
+Settings can be changed at runtime and will be applied without the need for restarting your app. In the case of invalid config (e.g. missing hostname) the change will be ignored.
+
 ### Additional Fields
 
 By default, `logger` and `exception` fields are included on all messages (the `exception` field is only added when an exception is passed to the logger). There are a number of other ways to attach data to logs.

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Controllers/WeatherForecastController.cs
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Controllers/WeatherForecastController.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Gelf.Extensions.Logging.Samples.AspNetCore5.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            _logger.LogInformation("Getting weather at {weather_time}", DateTime.Now);
+            _logger.LogDebug("A debug level log");
+
+            var rng = new Random();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = rng.Next(-20, 55),
+                    Summary = Summaries[rng.Next(Summaries.Length)]
+                })
+                .ToArray();
+        }
+    }
+}

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Gelf.Extensions.Logging.Samples.AspNetCore5.csproj
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Gelf.Extensions.Logging.Samples.AspNetCore5.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Gelf.Extensions.Logging\Gelf.Extensions.Logging.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Program.cs
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Program.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Gelf.Extensions.Logging.Samples.AspNetCore5
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => webBuilder
+                    .UseStartup<Startup>()
+                    .ConfigureLogging((context, loggingBuilder) => loggingBuilder
+                        .AddGelf(options =>
+                        {
+                            options.LogSource = context.HostingEnvironment.ApplicationName;
+                            options.AdditionalFields["machine_name"] = Environment.MachineName;
+                            options.AdditionalFields["app_version"] = Assembly.GetEntryAssembly()
+                                !.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                                !.InformationalVersion;
+                        })));
+    }
+}

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Properties/launchSettings.json
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:49923",
+      "sslPort": 44374
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Gelf.Extensions.Logging.Samples.AspNetCore5": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Startup.cs
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/Startup.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+
+namespace Gelf.Extensions.Logging.Samples.AspNetCore5
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1",
+                    new OpenApiInfo {Title = "Gelf.Extensions.Logging.Samples.AspNetCore5", Version = "v1"});
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c =>
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Gelf.Extensions.Logging.Samples.AspNetCore5 v1"));
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+        }
+    }
+}

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/WeatherForecast.cs
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Gelf.Extensions.Logging.Samples.AspNetCore5
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int) (TemperatureC / 0.5556);
+
+        public string Summary { get; set; }
+    }
+}

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/appsettings.Development.json
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/appsettings.json
+++ b/samples/Gelf.Extensions.Logging.Samples.AspNetCore5/appsettings.json
@@ -1,0 +1,21 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "GELF": {
+      "Host": "localhost",
+      "Protocol": "HTTP",
+      "Port": "12202",
+      "AdditionalFields": {
+        "protocol": "http"
+      },
+      "LogLevel": {
+        "Gelf.Extensions.Logging.Samples.AspNetCore5.Controllers": "Debug"
+      }
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Gelf.Extensions.Logging/Debouncer.cs
+++ b/src/Gelf.Extensions.Logging/Debouncer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gelf.Extensions.Logging
+{
+    internal static class Debouncer
+    {
+        public static Action<T> Debounce<T>(Action<T> action, TimeSpan delay)
+        {
+            CancellationTokenSource? cts = null;
+
+            return parameter =>
+            {
+                try
+                {
+                    cts?.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+
+                var newCts = cts = new CancellationTokenSource();
+                Task.Delay(delay, newCts.Token)
+                    .ContinueWith(_ => action(parameter), newCts.Token)
+                    .ContinueWith(_ => newCts.Dispose(), newCts.Token);
+            };
+        }
+    }
+}

--- a/src/Gelf.Extensions.Logging/GelfLoggerOptionsSetup.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptionsSetup.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Options;
 
 namespace Gelf.Extensions.Logging
 {
-    public class GelfLoggerOptionsSetup : ConfigureFromConfigurationOptions<GelfLoggerOptions>
+    internal class GelfLoggerOptionsSetup : ConfigureFromConfigurationOptions<GelfLoggerOptions>
     {
         public GelfLoggerOptionsSetup(ILoggerProviderConfiguration<GelfLoggerProvider> providerConfiguration)
             : base(providerConfiguration.Configuration)

--- a/src/Gelf.Extensions.Logging/GelfMessageProcessor.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessageProcessor.cs
@@ -7,19 +7,20 @@ namespace Gelf.Extensions.Logging
 {
     public class GelfMessageProcessor
     {
-        private readonly IGelfClient _gelfClient;
         private readonly BufferBlock<GelfMessage> _messageBuffer;
 
         private Task _processorTask = Task.CompletedTask;
 
         public GelfMessageProcessor(IGelfClient gelfClient)
         {
-            _gelfClient = gelfClient;
+            GelfClient = gelfClient;
             _messageBuffer = new BufferBlock<GelfMessage>(new DataflowBlockOptions
             {
                 BoundedCapacity = 10000
             });
         }
+
+        internal IGelfClient GelfClient { get; set; }
 
         public void Start()
         {
@@ -33,7 +34,7 @@ namespace Gelf.Extensions.Logging
                 try
                 {
                     var message = await _messageBuffer.ReceiveAsync();
-                    await _gelfClient.SendMessageAsync(message);
+                    await GelfClient.SendMessageAsync(message);
                 }
                 catch (InvalidOperationException)
                 {

--- a/src/Gelf.Extensions.Logging/LoggerFactoryExtensions.cs
+++ b/src/Gelf.Extensions.Logging/LoggerFactoryExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Gelf.Extensions.Logging
 {
@@ -11,10 +13,44 @@ namespace Gelf.Extensions.Logging
         /// <param name="loggerFactory"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public static ILoggerFactory AddGelf(this ILoggerFactory loggerFactory, GelfLoggerOptions options)
+        public static ILoggerFactory AddGelf(
+            this ILoggerFactory loggerFactory, IOptionsMonitor<GelfLoggerOptions> options)
         {
             loggerFactory.AddProvider(new GelfLoggerProvider(options));
             return loggerFactory;
+        }
+
+        /// <summary>
+        ///     Adds a <see cref="GelfLoggerProvider" /> to the logger factory with the supplied
+        ///     <see cref="GelfLoggerOptions" />.
+        /// </summary>
+        /// <param name="loggerFactory"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static ILoggerFactory AddGelf(this ILoggerFactory loggerFactory, GelfLoggerOptions options)
+        {
+            return loggerFactory.AddGelf(new OptionsMonitorStub<GelfLoggerOptions>(options));
+        }
+
+        private class OptionsMonitorStub<T> : IOptionsMonitor<T>
+        {
+            public OptionsMonitorStub(T options)
+            {
+                CurrentValue = options;
+            }
+
+            public T CurrentValue { get; }
+
+            public T Get(string name) => CurrentValue;
+
+            public IDisposable OnChange(Action<T, string> listener) => new NullDisposable();
+
+            private class NullDisposable : IDisposable
+            {
+                public void Dispose()
+                {
+                }
+            }
         }
     }
 }

--- a/src/Gelf.Extensions.Logging/LoggingBuilderExtensions.cs
+++ b/src/Gelf.Extensions.Logging/LoggingBuilderExtensions.cs
@@ -17,8 +17,15 @@ namespace Gelf.Extensions.Logging
         public static ILoggingBuilder AddGelf(this ILoggingBuilder builder)
         {
             builder.AddConfiguration();
-            builder.Services.AddSingleton<ILoggerProvider, GelfLoggerProvider>();
-            builder.Services.TryAddSingleton<IConfigureOptions<GelfLoggerOptions>, GelfLoggerOptionsSetup>();
+
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<ILoggerProvider, GelfLoggerProvider>());
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IConfigureOptions<GelfLoggerOptions>, GelfLoggerOptionsSetup>());
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<
+                    IOptionsChangeTokenSource<GelfLoggerOptions>,
+                    LoggerProviderOptionsChangeTokenSource<GelfLoggerOptions, GelfLoggerProvider>>());
 
             return builder;
         }

--- a/test/Gelf.Extensions.Logging.Tests/LoggingBuilderExtensionsTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/LoggingBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,7 +12,7 @@ namespace Gelf.Extensions.Logging.Tests
     public class LoggingBuilderExtensionsTests
     {
         [Fact]
-        public void Reads_GELF_logger_options_from_logging_configuration_section_by_default()
+        public void Reads_GELF_logger_options_from_logging_configuration_section()
         {
             var configuration = new ConfigurationBuilder().Add(new MemoryConfigurationSource
             {
@@ -19,7 +20,7 @@ namespace Gelf.Extensions.Logging.Tests
                 {
                     ["Logging:GELF:IncludeScopes"] = "false",
                     ["Logging:GELF:Protocol"] = "HTTP",
-                    ["Logging:GELF:Host"] = "graylog-host-1"
+                    ["Logging:GELF:Host"] = "graylog-host"
                 }
             }).Build();
 
@@ -33,56 +34,14 @@ namespace Gelf.Extensions.Logging.Tests
 
             Assert.False(options.Value.IncludeScopes);
             Assert.Equal(GelfProtocol.Http, options.Value.Protocol);
-            Assert.Equal("graylog-host-1", options.Value.Host);
+            Assert.Equal("graylog-host", options.Value.Host);
             Assert.Equal("post-configured-log-source", options.Value.LogSource);
         }
 
         [Fact]
-        public void Reads_GELF_logger_options_from_custom_configuration_section()
+        public void Reads_GELF_logger_options_default_values()
         {
-            var configuration = new ConfigurationBuilder().Add(new MemoryConfigurationSource
-            {
-                InitialData = new Dictionary<string, string>
-                {
-                    ["Logging:GELF:IncludeScopes"] = "true",
-                    ["Logging:GELF:Protocol"] = "HTTP",
-                    ["Logging:GELF:Host"] = "graylog-host-1",
-                    ["Graylog:IncludeScopes"] = "false",
-                    ["Graylog:Protocol"] = "HTTPS",
-                    ["Graylog:Host"] = "graylog-host-2"
-                }
-            }).Build();
-
-            var serviceCollection = new ServiceCollection()
-                .Configure<GelfLoggerOptions>(configuration.GetSection("Graylog"))
-                .PostConfigure<GelfLoggerOptions>(o => o.LogSource = "post-configured-log-source")
-                .AddLogging(loggingBuilder => loggingBuilder
-                    .AddConfiguration(configuration.GetSection("Logging"))
-                    .AddGelf(o => o.LogSource = "post-configured-log-source"));
-
-            using var provider = serviceCollection.BuildServiceProvider();
-            var options = provider.GetRequiredService<IOptions<GelfLoggerOptions>>();
-
-            Assert.False(options.Value.IncludeScopes);
-            Assert.Equal(GelfProtocol.Https, options.Value.Protocol);
-            Assert.Equal("graylog-host-2", options.Value.Host);
-            Assert.Equal("post-configured-log-source", options.Value.LogSource);
-        }
-
-        [Fact]
-        public void Reads_GELF_logger_options_with_default_udpmaxchunksize()
-        {
-            var defaultMaxChunkSize = 8192;
-
-            var configuration = new ConfigurationBuilder().Add(new MemoryConfigurationSource
-            {
-                InitialData = new Dictionary<string, string>
-                {
-                    ["Logging:GELF:IncludeScopes"] = "false",
-                    ["Logging:GELF:Protocol"] = "HTTP",
-                    ["Logging:GELF:Host"] = "graylog-host-1"
-                }
-            }).Build();
+            var configuration = new ConfigurationBuilder().Build();
 
             var serviceCollection = new ServiceCollection()
                 .AddLogging(loggingBuilder => loggingBuilder
@@ -92,60 +51,14 @@ namespace Gelf.Extensions.Logging.Tests
             using var provider = serviceCollection.BuildServiceProvider();
             var options = provider.GetRequiredService<IOptions<GelfLoggerOptions>>();
 
-            Assert.Equal(options.Value.UdpMaxChunkSize, defaultMaxChunkSize);
-        }
-
-        [Fact]
-        public void Reads_GELF_logger_options_with_custom_udpmaxchunksize()
-        {
-            var customChunkSize = 1024;
-
-            var configuration = new ConfigurationBuilder().Add(new MemoryConfigurationSource
-            {
-                InitialData = new Dictionary<string, string>
-                {
-                    ["Logging:GELF:IncludeScopes"] = "false",
-                    ["Logging:GELF:Protocol"] = "HTTP",
-                    ["Logging:GELF:Host"] = "graylog-host-1",
-                    ["Logging:GELF:UdpMaxChunkSize"] = customChunkSize.ToString()
-                }
-            }).Build();
-
-            var serviceCollection = new ServiceCollection()
-                .AddLogging(loggingBuilder => loggingBuilder
-                    .AddConfiguration(configuration.GetSection("Logging"))
-                    .AddGelf());
-
-            using var provider = serviceCollection.BuildServiceProvider();
-            var options = provider.GetRequiredService<IOptions<GelfLoggerOptions>>();
-
-            Assert.Equal(options.Value.UdpMaxChunkSize, customChunkSize);
-        }
-
-        [Fact]
-        public void Reads_GELF_logger_options_with_custom_udpmaxchunksize_post_configuration()
-        {
-            var customChunkSize = 1024;
-
-            var configuration = new ConfigurationBuilder().Add(new MemoryConfigurationSource
-            {
-                InitialData = new Dictionary<string, string>
-                {
-                    ["Logging:GELF:IncludeScopes"] = "false",
-                    ["Logging:GELF:Protocol"] = "HTTP",
-                    ["Logging:GELF:Host"] = "graylog-host-1"
-                }
-            }).Build();
-
-            var serviceCollection = new ServiceCollection()
-                .AddLogging(loggingBuilder => loggingBuilder
-                    .AddConfiguration(configuration.GetSection("Logging"))
-                    .AddGelf(o => o.UdpMaxChunkSize = customChunkSize));
-
-            using var provider = serviceCollection.BuildServiceProvider();
-            var options = provider.GetRequiredService<IOptions<GelfLoggerOptions>>();
-
-            Assert.Equal(options.Value.UdpMaxChunkSize, customChunkSize);
+            Assert.Equal(GelfProtocol.Udp, options.Value.Protocol);
+            Assert.Equal(12201, options.Value.Port);
+            Assert.Equal(512, options.Value.UdpCompressionThreshold);
+            Assert.Equal(8192, options.Value.UdpMaxChunkSize);
+            Assert.Equal(TimeSpan.FromSeconds(30), options.Value.HttpTimeout);
+            Assert.True(options.Value.IncludeScopes);
+            Assert.True(options.Value.CompressUdp);
+            Assert.False(options.Value.IncludeMessageTemplates);
         }
     }
 }


### PR DESCRIPTION
Logger provider now subscribes to options changed events and recreates GELF clients. Events are debounced with an interval of 1 second to avoid [duplicates](https://github.com/dotnet/runtime/issues/36045).