### PR TITLE
Add TCP Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Logger options are taken from the "GELF" provider section in `appsettings.json` 
 }
 ```
 
-For a full list of options e.g. UDP/HTTP(S) settings, see [`GelfLoggerOptions`](src/Gelf.Extensions.Logging/GelfLoggerOptions.cs). See the [samples](/samples) directory full examples. For more information on providers and logging in general, see the aspnetcore [logging documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging).
+For a full list of options e.g. UDP/TCP/HTTP(S) settings, see [`GelfLoggerOptions`](src/Gelf.Extensions.Logging/GelfLoggerOptions.cs). See the [samples](/samples) directory full examples. For more information on providers and logging in general, see the aspnetcore [logging documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging).
 
 ### Auto Reloading Config
 

--- a/samples/Gelf.Extensions.Logging.Samples.NetCore1/appsettings.json
+++ b/samples/Gelf.Extensions.Logging.Samples.NetCore1/appsettings.json
@@ -9,7 +9,9 @@
       "Host": "localhost",
       "Port": 12201,
       "LogSource": "console-app-1",
-      "LogLevel": "Trace",
+      "LogLevel": {
+        "Default": "Trace"
+      },
       "AdditionalFields": {
         "project_name": "my-project"
       }

--- a/samples/Gelf.Extensions.Logging.Samples.NetCore1/appsettings.json
+++ b/samples/Gelf.Extensions.Logging.Samples.NetCore1/appsettings.json
@@ -9,9 +9,7 @@
       "Host": "localhost",
       "Port": 12201,
       "LogSource": "console-app-1",
-      "LogLevel": {
-        "Default": "Trace"
-      },
+      "LogLevel": "Trace",
       "AdditionalFields": {
         "project_name": "my-project"
       }

--- a/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
@@ -32,6 +32,16 @@ namespace Gelf.Extensions.Logging
         public string? LogSource { get; set; }
 
         /// <summary>
+        ///     Set maximum duration to wait for TCP requests to wait before cancelling (Default 1000).
+        /// </summary>
+        public int TcpTimeoutMs { get; set; } = 1000;
+
+        /// <summary>
+        ///     If set to true, TCP errors will be thrown to the caller. (Default false).
+        /// </summary>
+        public bool ThrowTcpExceptions { get; set; } = true;
+
+        /// <summary>
         ///     Enable GZip message compression for UDP logging.
         /// </summary>
         public bool CompressUdp { get; set; } = true;

--- a/src/Gelf.Extensions.Logging/GelfLoggerProvider.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerProvider.cs
@@ -83,6 +83,7 @@ namespace Gelf.Extensions.Logging
             return options.Protocol switch
             {
                 GelfProtocol.Udp => new UdpGelfClient(options),
+                GelfProtocol.Tcp => new TcpGelfClient(options),
                 GelfProtocol.Http => new HttpGelfClient(options),
                 GelfProtocol.Https => new HttpGelfClient(options),
                 _ => throw new ArgumentException("Unknown protocol.", nameof(options))

--- a/src/Gelf.Extensions.Logging/GelfProtocol.cs
+++ b/src/Gelf.Extensions.Logging/GelfProtocol.cs
@@ -3,6 +3,7 @@
     public enum GelfProtocol
     {
         Udp,
+        Tcp,
         Http,
         Https
     }

--- a/src/Gelf.Extensions.Logging/TcpGelfClient.cs
+++ b/src/Gelf.Extensions.Logging/TcpGelfClient.cs
@@ -1,0 +1,69 @@
+﻿using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gelf.Extensions.Logging;
+
+public class TcpGelfClient : IGelfClient
+{
+    private readonly ReaderWriterLockSlim _lockSlim = new();
+    private readonly GelfLoggerOptions _options;
+    private TcpClient? _client;
+    private Stream? _stream;
+
+    public TcpGelfClient(GelfLoggerOptions options)
+    {
+        _options = options;
+    }
+
+    public void Dispose()
+    {
+        _lockSlim.Dispose();
+        _stream?.Dispose();
+        _client?.Dispose();
+    }
+
+    public async Task SendMessageAsync(GelfMessage message)
+    {
+        var messageBytes = Encoding.UTF8.GetBytes(message.ToJson() + '\0');
+        try
+        {
+            var stream = GetStream();
+            await stream.WriteAsync(messageBytes, 0, messageBytes.Length);
+        }
+        catch (SocketException)
+        {
+            if (_options.ThrowTcpExceptions)
+                throw;
+        }
+    }
+
+    private Stream GetStream()
+    {
+        _lockSlim.EnterUpgradeableReadLock();
+        try
+        {
+            if (_client?.Connected == true && _stream != null)
+                return _stream;
+
+            _lockSlim.EnterWriteLock();
+            try
+            {
+                _client =
+                    new TcpClient(_options.Host!, _options.Port) {SendTimeout = _options.TcpTimeoutMs};
+                _stream = _client.GetStream();
+                return _stream;
+            }
+            finally
+            {
+                _lockSlim.ExitWriteLock();
+            }
+        }
+        finally
+        {
+            _lockSlim.ExitUpgradeableReadLock();
+        }
+    }
+}

--- a/src/Gelf.Extensions.Logging/UdpGelfClient.cs
+++ b/src/Gelf.Extensions.Logging/UdpGelfClient.cs
@@ -25,7 +25,7 @@ namespace Gelf.Extensions.Logging
         {
             _options = options;
             _maxMessageBodySize = options.UdpMaxChunkSize - MessageHeaderSize;
-            _udpClient = new UdpClient(_options.Host, _options.Port);
+            _udpClient = new UdpClient(_options.Host!, _options.Port);
             _random = new Random();
         }
 

--- a/test/Gelf.Extensions.Logging.Tests/Fixtures/GraylogFixture.cs
+++ b/test/Gelf.Extensions.Logging.Tests/Fixtures/GraylogFixture.cs
@@ -72,7 +72,7 @@ namespace Gelf.Extensions.Logging.Tests.Fixtures
         private async Task<string> CreateInputAsync()
         {
             List<dynamic> existingInputs = (await _httpClient.GetAsync("system/inputs")).inputs;
-            var input = existingInputs.SingleOrDefault(i => i.attributes.port == InputPort);
+            var input = existingInputs.SingleOrDefault(i => i.attributes.port == InputPort && i.type == InputType);
             if (input != null)
             {
                 return input.id;

--- a/test/Gelf.Extensions.Logging.Tests/Fixtures/TcpGraylogFixture.cs
+++ b/test/Gelf.Extensions.Logging.Tests/Fixtures/TcpGraylogFixture.cs
@@ -1,0 +1,16 @@
+﻿using Xunit.Abstractions;
+
+namespace Gelf.Extensions.Logging.Tests.Fixtures
+{
+    public class TcpGraylogFixture : GraylogFixture
+    {
+        public TcpGraylogFixture(IMessageSink messageSink) : base(messageSink)
+        {
+        }
+        public override int InputPort => 12201;
+
+        protected override string InputType => "org.graylog2.inputs.gelf.tcp.GELFTCPInput";
+
+        protected override string InputTitle => "Gelf.Extensions.Logging.Tests.Tcp";
+    }
+}

--- a/test/Gelf.Extensions.Logging.Tests/TcpGelfLoggerTests.cs
+++ b/test/Gelf.Extensions.Logging.Tests/TcpGelfLoggerTests.cs
@@ -1,0 +1,19 @@
+﻿using Gelf.Extensions.Logging.Tests.Fixtures;
+using Xunit;
+
+namespace Gelf.Extensions.Logging.Tests
+{
+    public class TcpGelfLoggerTests : GelfLoggerTests, IClassFixture<TcpGraylogFixture>
+    {
+        public TcpGelfLoggerTests(TcpGraylogFixture graylogFixture) : base(graylogFixture,
+            new LoggerFixture(new GelfLoggerOptions
+            {
+                Host = GraylogFixture.Host,
+                Port = graylogFixture.InputPort,
+                Protocol = GelfProtocol.Tcp,
+                LogSource = nameof(TcpGelfLoggerTests)
+            }))
+        {
+        }
+    }
+}


### PR DESCRIPTION
A single TCP stream will be used, using a configurable default timeout of 1000ms.
By default, all TCP errors will be ignored. By enabling `ThrowTcpExceptions` in the options, the TCP exceptions will propagate to the application, which could be useful for debugging purposes.

Solves issue #64 