### PR TITLE
Support key customization for optional fields.

### DIFF
--- a/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
@@ -70,5 +70,53 @@ namespace Gelf.Extensions.Logging
         ///     Include a field with the original message template before structured log parameters are replaced.
         /// </summary>
         public bool IncludeMessageTemplates { get; set; }
+
+        /// <summary>
+        ///     The field key to use for the logger name, or null to omit.
+        /// </summary>
+        public string? LoggerFieldKey
+        {
+            get => _loggerField.Key;
+            set => _loggerField = FieldFromValue(value);
+        }
+
+        /// <summary>
+        ///     The field key to use for the exception details, or null to omit.
+        /// </summary>
+        public string? ExceptionFieldKey
+        {
+            get => _exceptionField.Key;
+            set => _exceptionField = FieldFromValue(value);
+        }
+
+        /// <summary>
+        ///     The field key to use for the event ID, or null to omit.
+        /// </summary>
+        public string? EventIdFieldKey
+        {
+            get => _eventIdField.Key;
+            set => _eventIdField = FieldFromValue(value);
+        }
+
+        /// <summary>
+        ///     The field key to use for the event name, or null to omit.
+        /// </summary>
+        public string? EventNameFieldKey
+        {
+            get => _eventNameField.Key;
+            set => _eventNameField = FieldFromValue(value);
+        }
+
+        internal string? LoggerPropertyName => _loggerField.Name;
+        internal string? ExceptionPropertyName => _exceptionField.Name;
+        internal string? EventIdPropertyName => _eventIdField.Name;
+        internal string? EventNamePropertyName => _eventNameField.Name;
+
+        private static (string? Key, string? Name) FieldFromValue(string? value) => value == null ? default : (value, $"_{value}");
+
+        private (string? Key, string? Name) _loggerField = FieldFromValue("logger");
+        private (string? Key, string? Name) _exceptionField = FieldFromValue("exception");
+        private (string? Key, string? Name) _eventIdField = FieldFromValue("event_id");
+        private (string? Key, string? Name) _eventNameField = FieldFromValue("event_name");
     }
 }

--- a/src/Gelf.Extensions.Logging/GelfMessage.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessage.cs
@@ -26,5 +26,10 @@ namespace Gelf.Extensions.Logging
 
         public IReadOnlyCollection<KeyValuePair<string, object>> AdditionalFields { get; set; } =
             Array.Empty<KeyValuePair<string, object>>();
+
+        internal string? LoggerPropertyName { get; set; }
+        internal string? ExceptionPropertyName { get; set; }
+        internal string? EventIdPropertyName { get; set; }
+        internal string? EventNamePropertyName { get; set; }
     }
 }

--- a/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
+++ b/src/Gelf.Extensions.Logging/GelfMessageExtensions.cs
@@ -18,10 +18,10 @@ namespace Gelf.Extensions.Logging
             jsonWriter.WriteStringUnlessNull("short_message", message.ShortMessage);
             jsonWriter.WriteNumber("timestamp", message.Timestamp);
             jsonWriter.WriteNumber("level", (int) message.Level);
-            jsonWriter.WriteStringUnlessNull("_logger", message.Logger);
-            jsonWriter.WriteStringUnlessNull("_exception", message.Exception);
-            jsonWriter.WriteNumberUnlessNull("_event_id", message.EventId);
-            jsonWriter.WriteStringUnlessNull("_event_name", message.EventName);
+            jsonWriter.WriteStringUnlessNull(message.LoggerPropertyName, message.Logger);
+            jsonWriter.WriteStringUnlessNull(message.ExceptionPropertyName, message.Exception);
+            jsonWriter.WriteNumberUnlessNull(message.EventIdPropertyName, message.EventId);
+            jsonWriter.WriteStringUnlessNull(message.EventNamePropertyName, message.EventName);
 
             foreach (var field in message.AdditionalFields)
             {
@@ -81,17 +81,17 @@ namespace Gelf.Extensions.Logging
             }
         }
 
-        private static void WriteStringUnlessNull(this Utf8JsonWriter jsonWriter, string propertyName, string? value)
+        private static void WriteStringUnlessNull(this Utf8JsonWriter jsonWriter, string? propertyName, string? value)
         {
-            if (value != null)
+            if (propertyName != null && value != null)
             {
                 jsonWriter.WriteString(propertyName, value);
             }
         }
 
-        private static void WriteNumberUnlessNull(this Utf8JsonWriter jsonWriter, string propertyName, int? value)
+        private static void WriteNumberUnlessNull(this Utf8JsonWriter jsonWriter, string? propertyName, int? value)
         {
-            if (value != null)
+            if (propertyName != null && value != null)
             {
                 jsonWriter.WriteNumber(propertyName, value.Value);
             }


### PR DESCRIPTION
We would like more precise control of how the optional fields are logged (`logger`, `exception`, `event_id`, and `event_name`). This change allows those fields to be renamed or omitted entirely.