### PR TITLE
Change AdditionalFieldsFactory to return an enumerable of key/value pairs.

### DIFF
--- a/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerOptions.cs
@@ -54,7 +54,7 @@ namespace Gelf.Extensions.Logging
         /// <summary>
         ///     Additional fields computed based on raw log data.
         /// </summary>
-        public Func<GelfLogContext, Dictionary<string, object?>>? AdditionalFieldsFactory { get; set; }
+        public Func<GelfLogContext, IEnumerable<KeyValuePair<string, object?>>>? AdditionalFieldsFactory { get; set; }
 
         /// <summary>
         ///     Headers used when sending logs via HTTP(S).


### PR DESCRIPTION
A dictionary can still be used, but this allows callers to return an array of key/value pairs for reduced overhead.