### PR TITLE
Clear the UdpClient.DontFragment flag. Fixes #79.

### DIFF
--- a/src/Gelf.Extensions.Logging/UdpGelfClient.cs
+++ b/src/Gelf.Extensions.Logging/UdpGelfClient.cs
@@ -25,7 +25,7 @@ namespace Gelf.Extensions.Logging
         {
             _options = options;
             _maxMessageBodySize = options.UdpMaxChunkSize - MessageHeaderSize;
-            _udpClient = new UdpClient(_options.Host!, _options.Port);
+            _udpClient = new UdpClient(_options.Host!, _options.Port) { DontFragment = false };
             _random = new Random();
         }
 


### PR DESCRIPTION
I tried pretty hard to get the Dockerized tests to reproduce the issue, but without success. Loopback interfaces (on Windows and Linux) have maximum MTUs (64k on Linux, -1 on Windows, both of which are larger than the maximum UDP packet size). So it's not possible to repro this on Docker _or_ Windows unless you change the MTU for the loopback interface, and I didn't find a good way to do that safely and reliably.