### PR TITLE
Ensure safe app start in case server dns problem exception is thrown

### DIFF
--- a/src/Gelf.Extensions.Logging/GelfLoggerProvider.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerProvider.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Collections.Concurrent;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Concurrent;
 
 namespace Gelf.Extensions.Logging
 {
@@ -29,6 +30,10 @@ namespace Gelf.Extensions.Logging
 
         public ILogger CreateLogger(string name)
         {
+            if (_messageProcessor is null)
+            {
+                return NullLogger.Instance;
+            }
             return _loggers.GetOrAdd(name, newName => new GelfLogger(
                 newName, _messageProcessor!, _options.CurrentValue)
             {
@@ -47,34 +52,41 @@ namespace Gelf.Extensions.Logging
 
         private void LoadLoggerOptions(GelfLoggerOptions options)
         {
-            if (string.IsNullOrEmpty(options.Host))
+            try
             {
-                throw new ArgumentException("GELF host is required.", nameof(options));
+                if (string.IsNullOrEmpty(options.Host))
+                {
+                    throw new ArgumentException("GELF host is required.", nameof(options));
+                }
+
+                if (string.IsNullOrEmpty(options.LogSource))
+                {
+                    throw new ArgumentException("GELF log source is required.", nameof(options));
+                }
+
+                var gelfClient = CreateGelfClient(options);
+
+                if (_messageProcessor == null)
+                {
+                    _messageProcessor = new GelfMessageProcessor(gelfClient);
+                    _messageProcessor.Start();
+                }
+                else
+                {
+                    _messageProcessor.GelfClient = gelfClient;
+                    _gelfClient?.Dispose();
+                }
+
+                _gelfClient = gelfClient;
+
+                foreach (var logger in _loggers)
+                {
+                    logger.Value.Options = options;
+                }
             }
-
-            if (string.IsNullOrEmpty(options.LogSource))
+            catch (Exception ex)
             {
-                throw new ArgumentException("GELF log source is required.", nameof(options));
-            }
-
-            var gelfClient = CreateGelfClient(options);
-
-            if (_messageProcessor == null)
-            {
-                _messageProcessor = new GelfMessageProcessor(gelfClient);
-                _messageProcessor.Start();
-            }
-            else
-            {
-                _messageProcessor.GelfClient = gelfClient;
-                _gelfClient?.Dispose();
-            }
-
-            _gelfClient = gelfClient;
-
-            foreach (var logger in _loggers)
-            {
-                logger.Value.Options = options;
+                Console.WriteLine(ex.ToString());
             }
         }
 

--- a/src/Gelf.Extensions.Logging/GelfLoggerProvider.cs
+++ b/src/Gelf.Extensions.Logging/GelfLoggerProvider.cs
@@ -86,7 +86,8 @@ namespace Gelf.Extensions.Logging
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.ToString());
+                Console.Error.WriteLine("GELF logger initialization failed. Logging will be degraded. Exception details:");
+                Console.Error.WriteLine(ex.ToString());
             }
         }
 


### PR DESCRIPTION
When using gelf with server dns endpoint, if dns fails, application fails to start as Exception propagates to application startup, causing app to crash.